### PR TITLE
Improve error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ const sendPeriodicMessageToAllClients = () => {
 
 app.get("/settings/current", (req, res) => {
   Setting.findById(setting._id, (err, copiedSettings) => {
-    if (err) throw err;
+    if (!err) throw err;
 
     res.status(200).json({
       success: true,

--- a/app.js
+++ b/app.js
@@ -21,8 +21,10 @@ mongoose.connect(runtimeVariables.dbURI, err => {
     }
   }
 
-  Setting.countDocuments({}, (_, count) => {
-    const dbIsEmpty = count === 0;
+  Setting.find({}, (err, data) => {
+    if (err) throw err;
+
+    const dbIsEmpty = data.length === 0;
 
     if (dbIsEmpty) {
       setting = new Setting();
@@ -30,6 +32,8 @@ mongoose.connect(runtimeVariables.dbURI, err => {
       setting.save(err => {
         if (err) throw err;
       });
+    } else {
+      setting = data[0];
     }
   });
 });

--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ const sendPeriodicMessageToAllClients = () => {
 
 app.get("/settings/current", (req, res) => {
   Setting.findById(setting._id, (err, copiedSettings) => {
-    if (!err) throw err;
+    if (err) throw err;
 
     res.status(200).json({
       success: true,

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     </head>
     <body>
         <h1>ws-anywhere</h1>
+
+        <div id="errorMsgBox" class="errorMsgBox">
+          <img src="assets/error.png" width="25" height="25" alt="Error" />
+        </div>
+
         <h2>Customizable WebSocket test server</h2>
         <p>WebSocket connections can only be established on the index route.</p>
         <p>The objects are serialized as the WebSocket API doens't support sending raw objects. As a result, the received dummy data in the client side is stringified by <i>JSON.stringify()</i>.</p>
@@ -21,10 +26,6 @@
 
         <h3>How to use?</h3>
         <p>There are two different ways to use the server:
-
-        <div id="errorMsgBox" class="errorMsgBox">
-          <img src="assets/error.png" width="25" height="25" alt="Error" />
-        </div>
 
         <div>
             <h4>1. PER SEND EVENT</h4>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,9 @@
 
         <h3>How to use?</h3>
         <p>There are two different ways to use the server:
-        
+
+        <div id="errorMsgBox" class="errorMsgBox"></div>
+
         <div>
             <h4>1. PER SEND EVENT</h4>
             <p>This is evoked whenever a <i>send</i> event has been sent towards the server.</p>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@
         <h3>How to use?</h3>
         <p>There are two different ways to use the server:
 
-        <div id="errorMsgBox" class="errorMsgBox"></div>
+        <div id="errorMsgBox" class="errorMsgBox">
+          <img src="assets/error.png" width="25" height="25" alt="Error" />
+        </div>
 
         <div>
             <h4>1. PER SEND EVENT</h4>

--- a/resources/index.css
+++ b/resources/index.css
@@ -40,10 +40,16 @@ button {
 
 .errorMsgBox {
   display: none;
-  width: 50%;
-  border: 3px solid red;
-  font-weight: bold;
-  background: #DBD9D9;
+  align-items: center;
+  width: 30%;
+  background: #e8aeae;
+  color: #2B2B2B;
+  text-align: left;
   margin: 0 auto;
-  padding: 15px;
+  padding: 10px 20px;
+  border-radius: 3px;
+}
+
+.errorMsgBox > img {
+  margin-right: 5px;
 }

--- a/resources/index.css
+++ b/resources/index.css
@@ -37,3 +37,13 @@ button {
     font-weight: bold;
     display: none;
 }
+
+.errorMsgBox {
+  display: none;
+  width: 50%;
+  border: 3px solid red;
+  font-weight: bold;
+  background: #DBD9D9;
+  margin: 0 auto;
+  padding: 15px;
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -174,8 +174,6 @@ function displayErrorMsgBox(errorMessage) {
   errorMsgBoxElement.appendChild(errorMsgBoxTextElement);
 
   errorMsgBoxElement.style.display = "flex";
-
-  hideElementAfterMsElapsed(errorMsgBoxElement, 2500);
 }
 
 function getErrorMessageBoxTextElement(errorMessage) {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -169,11 +169,21 @@ function displayErrorElements(elementIdsGroup, errorMessage) {
 function displayErrorMsgBox(errorMessage) {
   const errorMsgBoxElement = document.getElementById("errorMsgBox");
 
-  errorMsgBoxElement.innerText = errorMessage;
+  const errorMsgBoxTextElement = getErrorMessageBoxTextElement(errorMessage);
 
-  errorMsgBoxElement.style.display = "block";
+  errorMsgBoxElement.appendChild(errorMsgBoxTextElement);
+
+  errorMsgBoxElement.style.display = "flex";
 
   hideElementAfterMsElapsed(errorMsgBoxElement, 2500);
+}
+
+function getErrorMessageBoxTextElement(errorMessage) {
+  const errorMsgTextElement = document.createElement("P");
+
+  errorMsgTextElement.innerText = errorMessage;
+
+  return errorMsgTextElement;
 }
 
 function updatePeriodicActionButtonsDisabledProperty(btnStatuses) {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -365,8 +365,6 @@ function startSendingPeriodicMessage() {
         start: false,
         stop: true
       });
-
-      displayErrorMsgBox("Server error");
     });
 }
 
@@ -390,7 +388,5 @@ function stopSendingPeriodicMessage() {
         start: true,
         stop: false
       });
-
-      displayErrorMsgBox("Server error");
     });
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -27,8 +27,7 @@ window.onload = function() {
       }
     })
     .catch(() => {
-      displayErrorElements(elementIds.onEvent, "Server error");
-      displayErrorElements(elementIds.periodic, "Server error");
+      displayErrorMsgBox("Server error");
     });
 
   createFeedbackElements();
@@ -165,6 +164,16 @@ function displayErrorElements(elementIdsGroup, errorMessage) {
     elementsGroup.errorSpan.style.display = "block";
     elementsGroup.errorSpan.innerText = errorMessage;
   }
+}
+
+function displayErrorMsgBox(errorMessage) {
+  const errorMsgBoxElement = document.getElementById("errorMsgBox");
+
+  errorMsgBoxElement.innerText = errorMessage;
+
+  errorMsgBoxElement.style.display = "block";
+
+  hideElementAfterMsElapsed(errorMsgBoxElement, 2500);
 }
 
 function updatePeriodicActionButtonsDisabledProperty(btnStatuses) {
@@ -347,7 +356,7 @@ function startSendingPeriodicMessage() {
         stop: true
       });
 
-      displayErrorElements(elementIds.periodic, "Server error");
+      displayErrorMsgBox("Server error");
     });
 }
 
@@ -372,6 +381,6 @@ function stopSendingPeriodicMessage() {
         stop: false
       });
 
-      displayErrorElements(elementIds.periodic, "Server error");
+      displayErrorMsgBox("Server error");
     });
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -25,6 +25,10 @@ window.onload = function() {
       if (parsedResponseData.success) {
         setInputValues(parsedResponseData.currentSettings);
       }
+    })
+    .catch(() => {
+      displayErrorElements(elementIds.onEvent, "Server error");
+      displayErrorElements(elementIds.periodic, "Server error");
     });
 
   createFeedbackElements();
@@ -342,6 +346,8 @@ function startSendingPeriodicMessage() {
         start: false,
         stop: true
       });
+
+      displayErrorElements(elementIds.periodic, "Server error");
     });
 }
 
@@ -365,5 +371,7 @@ function stopSendingPeriodicMessage() {
         start: true,
         stop: false
       });
+
+      displayErrorElements(elementIds.periodic, "Server error");
     });
 }


### PR DESCRIPTION
Part of issue #19.

Broken server & error handling can be tested here:
https://c-hive-ws-demo.herokuapp.com/

Fixed the error in the BE. Basically, the `setting` variable should be reloaded with the actual data between the automatic Heroku restarts - only if the DB isn't empty. As a result, let's use `find` instead of `countDocuments`.

Furthermore, based on the relevant issue, also improved the error handling - simply just displaying the suggested `Server error` text whenever something goes wrong in the BE.

---

One question:

```js
.catch(() => {
      displayErrorElements(elementIds.onEvent, "Server error");
      displayErrorElements(elementIds.periodic, "Server error");
});
```

I don't really like this solution. What it actually does is display the `X` icon along with the `Server error` message next to both the *on event* and *periodic* buttons whenever an error occurs during querying the current data from the server.

Do you have any other idea, or it should be enough in this case?