### PR TITLE
Additional error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,9 +16,9 @@ mongoose.connect(runtimeVariables.dbURI, err => {
   if (err) {
     if (err.name === "MongoNetworkError") {
       throw new Error("Incorrect MongoDB connection uri.");
-    } else {
-      throw err;
     }
+
+    throw err;
   }
 
   Setting.find({}, (err, data) => {
@@ -71,21 +71,17 @@ app.get("/settings/current", (req, res) => {
   Setting.findById(setting._id, (err, copiedSettings) => {
     if (err) throw err;
 
-    res.status(200).json({
-      success: true,
+    return res.status(200).json({
       currentSettings: copiedSettings
     });
   });
 });
 
 app.post("/settings/onevent/save", (req, res) => {
-  Setting.findOneAndUpdate(setting._id, req.body, (err, updatedSettings) => {
+  Setting.findOneAndUpdate(setting._id, req.body, err => {
     if (err) throw err;
 
-    res.status(200).json({
-      success: true,
-      currentSettings: updatedSettings
-    });
+    return res.sendStatus(200);
   });
 });
 
@@ -99,10 +95,7 @@ app.post("/settings/periodic/save", (req, res) => {
       sendPeriodicMessageToAllClients();
     }
 
-    res.status(200).send({
-      success: true,
-      currentSettings: updatedSettings
-    });
+    return res.sendStatus(200);
   });
 });
 
@@ -116,9 +109,7 @@ app.get("/settings/periodic/start", (req, res) => {
 
     sendPeriodicMessageToAllClients();
 
-    res.status(200).json({
-      success: true
-    });
+    return res.sendStatus(200);
   });
 });
 
@@ -132,9 +123,7 @@ app.get("/settings/periodic/stop", (req, res) => {
 
     clearInterval(timer);
 
-    res.status(200).json({
-      success: true
-    });
+    return res.sendStatus(200);
   });
 });
 
@@ -143,9 +132,7 @@ app.get("/disconnect", (req, res) => {
     client.close();
   });
 
-  res.status(200).json({
-    success: true
-  });
+  return res.sendStatus(200);
 });
 
 app.ws("/", ws => {

--- a/app.js
+++ b/app.js
@@ -67,7 +67,13 @@ const sendPeriodicMessageToAllClients = () => {
   });
 };
 
+const settingsAreNotDefined = () => !javaScriptUtils.isDefined(setting);
+
 app.get("/settings/current", (req, res) => {
+  if (settingsAreNotDefined()) {
+    return res.sendStatus(500);
+  }
+
   Setting.findById(setting._id, (err, copiedSettings) => {
     if (err) throw err;
 
@@ -78,6 +84,10 @@ app.get("/settings/current", (req, res) => {
 });
 
 app.post("/settings/onevent/save", (req, res) => {
+  if (settingsAreNotDefined()) {
+    return res.sendStatus(500);
+  }
+
   Setting.findOneAndUpdate(setting._id, req.body, err => {
     if (err) throw err;
 
@@ -86,6 +96,10 @@ app.post("/settings/onevent/save", (req, res) => {
 });
 
 app.post("/settings/periodic/save", (req, res) => {
+  if (settingsAreNotDefined()) {
+    return res.sendStatus(500);
+  }
+
   Setting.findOneAndUpdate(setting._id, req.body, (err, updatedSettings) => {
     if (err) throw err;
 
@@ -100,6 +114,10 @@ app.post("/settings/periodic/save", (req, res) => {
 });
 
 app.get("/settings/periodic/start", (req, res) => {
+  if (settingsAreNotDefined()) {
+    return res.sendStatus(500);
+  }
+
   const data = {
     isPeriodicMessageSendingActive: true
   };
@@ -114,6 +132,10 @@ app.get("/settings/periodic/start", (req, res) => {
 });
 
 app.get("/settings/periodic/stop", (req, res) => {
+  if (settingsAreNotDefined()) {
+    return res.sendStatus(500);
+  }
+
   const data = {
     isPeriodicMessageSendingActive: false
   };
@@ -128,6 +150,10 @@ app.get("/settings/periodic/stop", (req, res) => {
 });
 
 app.get("/disconnect", (req, res) => {
+  if (settingsAreNotDefined()) {
+    return res.sendStatus(500);
+  }
+
   expressWs.getWss().clients.forEach(client => {
     client.close();
   });

--- a/app.js
+++ b/app.js
@@ -67,10 +67,8 @@ const sendPeriodicMessageToAllClients = () => {
   });
 };
 
-const settingIsNotDefined = () => !javaScriptUtils.isDefined(setting);
-
 app.get("/settings/current", (req, res) => {
-  if (settingIsNotDefined()) {
+  if (!javaScriptUtils.isDefined(setting)) {
     return res.sendStatus(500);
   }
 
@@ -84,7 +82,7 @@ app.get("/settings/current", (req, res) => {
 });
 
 app.post("/settings/onevent/save", (req, res) => {
-  if (settingIsNotDefined()) {
+  if (!javaScriptUtils.isDefined(setting)) {
     return res.sendStatus(500);
   }
 
@@ -96,7 +94,7 @@ app.post("/settings/onevent/save", (req, res) => {
 });
 
 app.post("/settings/periodic/save", (req, res) => {
-  if (settingIsNotDefined()) {
+  if (!javaScriptUtils.isDefined(setting)) {
     return res.sendStatus(500);
   }
 
@@ -114,7 +112,7 @@ app.post("/settings/periodic/save", (req, res) => {
 });
 
 app.get("/settings/periodic/start", (req, res) => {
-  if (settingIsNotDefined()) {
+  if (!javaScriptUtils.isDefined(setting)) {
     return res.sendStatus(500);
   }
 
@@ -132,7 +130,7 @@ app.get("/settings/periodic/start", (req, res) => {
 });
 
 app.get("/settings/periodic/stop", (req, res) => {
-  if (settingIsNotDefined()) {
+  if (!javaScriptUtils.isDefined(setting)) {
     return res.sendStatus(500);
   }
 
@@ -150,7 +148,7 @@ app.get("/settings/periodic/stop", (req, res) => {
 });
 
 app.get("/disconnect", (req, res) => {
-  if (settingIsNotDefined()) {
+  if (!javaScriptUtils.isDefined(setting)) {
     return res.sendStatus(500);
   }
 

--- a/app.js
+++ b/app.js
@@ -67,10 +67,10 @@ const sendPeriodicMessageToAllClients = () => {
   });
 };
 
-const settingsAreNotDefined = () => !javaScriptUtils.isDefined(setting);
+const settingIsNotDefined = () => !javaScriptUtils.isDefined(setting);
 
 app.get("/settings/current", (req, res) => {
-  if (settingsAreNotDefined()) {
+  if (settingIsNotDefined()) {
     return res.sendStatus(500);
   }
 
@@ -84,7 +84,7 @@ app.get("/settings/current", (req, res) => {
 });
 
 app.post("/settings/onevent/save", (req, res) => {
-  if (settingsAreNotDefined()) {
+  if (settingIsNotDefined()) {
     return res.sendStatus(500);
   }
 
@@ -96,7 +96,7 @@ app.post("/settings/onevent/save", (req, res) => {
 });
 
 app.post("/settings/periodic/save", (req, res) => {
-  if (settingsAreNotDefined()) {
+  if (settingIsNotDefined()) {
     return res.sendStatus(500);
   }
 
@@ -114,7 +114,7 @@ app.post("/settings/periodic/save", (req, res) => {
 });
 
 app.get("/settings/periodic/start", (req, res) => {
-  if (settingsAreNotDefined()) {
+  if (settingIsNotDefined()) {
     return res.sendStatus(500);
   }
 
@@ -132,7 +132,7 @@ app.get("/settings/periodic/start", (req, res) => {
 });
 
 app.get("/settings/periodic/stop", (req, res) => {
-  if (settingsAreNotDefined()) {
+  if (settingIsNotDefined()) {
     return res.sendStatus(500);
   }
 
@@ -150,7 +150,7 @@ app.get("/settings/periodic/stop", (req, res) => {
 });
 
 app.get("/disconnect", (req, res) => {
-  if (settingsAreNotDefined()) {
+  if (settingIsNotDefined()) {
     return res.sendStatus(500);
   }
 

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
                 <button type="button" onclick="submitPeriodicSettings()">Submit</button>
             </div>
             <div id="periodicActions" class="flexBar">
-                <button type="button" id="startBtn" onclick="startSendingPeriodicMessage()">Start</button>
-                <button type="button" id="stopBtn" onclick="stopSendingPeriodicMessage()">Stop</button>
+                <button type="button" disabled id="startBtn" onclick="startSendingPeriodicMessage()">Start</button>
+                <button type="button" disabled id="stopBtn" onclick="stopSendingPeriodicMessage()">Stop</button>
             </div>
         </div>
     </body>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -224,11 +224,6 @@ function setInputValues(data) {
       start: data.isPeriodicMessageSendingActive,
       stop: !data.isPeriodicMessageSendingActive
     });
-  } else {
-    updatePeriodicActionButtonsDisabledProperty({
-      start: true,
-      stop: true
-    });
   }
 }
 
@@ -238,14 +233,15 @@ function disconnectAllClients() {
     const postUrl = "/disconnect";
 
     fetch(postUrl)
-      .then(response => response.json())
-      .then(parsedResponse => {
-        if (parsedResponse.success) {
-          displaySuccessImg(buttonRowIds.DISCONNECT);
+      .then(response => {
+        if (responseIsSuccess(response)) {
+          return displaySuccessImg(buttonRowIds.DISCONNECT);
         }
+
+        throw new ResponseFailureError();
       })
       .catch(() => {
-        displayErrorElements(buttonRowIds.DISCONNECT);
+        displayErrorElements(buttonRowIds.DISCONNECT, "Server error");
       });
   }
 }
@@ -284,7 +280,7 @@ function checkIfPeriodicMessageIsValid() {
 }
 
 function responseIsSuccess(response) {
-  return response.ok && response.status === 200;
+  return response.ok === true;
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -34,9 +34,7 @@ window.onload = function() {
         return response.json();
       }
 
-      throw new ResponseFailureError(
-        "Error during querying the current settings, code: " + response.status
-      );
+      throw new ResponseFailureError();
     })
     .then(parsedResponseData => {
       setInputValues(parsedResponseData.currentSettings);
@@ -238,19 +236,13 @@ function disconnectAllClients() {
   if (confirm("Disconnect all the clients?")) {
     const postUrl = "/disconnect";
 
-    fetch(postUrl)
-      .then(response => {
-        if (responseIsSuccess(response)) {
-          return displaySuccessImg(buttonRowIds.DISCONNECT);
-        }
+    fetch(postUrl).then(response => {
+      if (responseIsSuccess(response)) {
+        return displaySuccessImg(buttonRowIds.DISCONNECT);
+      }
 
-        throw new ResponseFailureError(
-          "Error during disconnecting all clients, code: " + response.status
-        );
-      })
-      .catch(() => {
-        displayErrorElements(buttonRowIds.DISCONNECT, "Server error");
-      });
+      displayErrorElements(buttonRowIds.DISCONNECT, "Server error");
+    });
   }
 }
 
@@ -301,19 +293,13 @@ function submitOnEventMessage() {
       },
       method: "POST",
       body: JSON.stringify(onEventMessageSettings)
-    })
-      .then(response => {
-        if (responseIsSuccess(response)) {
-          return displaySuccessImg(buttonRowIds.ON_EVENT);
-        }
+    }).then(response => {
+      if (responseIsSuccess(response)) {
+        return displaySuccessImg(buttonRowIds.ON_EVENT);
+      }
 
-        throw new ResponseFailureError(
-          "Error during saving `onEvent` message, code: " + response.status
-        );
-      })
-      .catch(() => {
-        displayErrorElements(buttonRowIds.ON_EVENT, "Server error");
-      });
+      displayErrorElements(buttonRowIds.ON_EVENT, "Server error");
+    });
   } else {
     const errorMessage = "Invalid JSON format.";
 
@@ -335,25 +321,19 @@ function submitPeriodicSettings() {
       },
       method: "POST",
       body: JSON.stringify(perodicMessageSettings)
-    })
-      .then(response => {
-        if (responseIsSuccess(response)) {
-          displaySuccessImg(buttonRowIds.PERIODIC);
+    }).then(response => {
+      if (responseIsSuccess(response)) {
+        displaySuccessImg(buttonRowIds.PERIODIC);
 
-          if (peridocActionButtonsAreDisabled()) {
-            updatePeriodicActionButtonsDisabledProperty({
-              start: false
-            });
-          }
-        } else {
-          throw new ResponseFailureError(
-            "Error during saving `periodic` message, code: " + response.status
-          );
+        if (peridocActionButtonsAreDisabled()) {
+          updatePeriodicActionButtonsDisabledProperty({
+            start: false
+          });
         }
-      })
-      .catch(() => {
+      } else {
         displayErrorElements(buttonRowIds.PERIODIC, "Server error");
-      });
+      }
+    });
   } else {
     const errorMessage = "Invalid JSON format.";
 
@@ -377,10 +357,7 @@ function startSendingPeriodicMessage() {
         return displaySuccessImg(buttonRowIds.PERIODIC_ACTIONS);
       }
 
-      throw new ResponseFailureError(
-        "An error occurred while processing start request, code: " +
-          response.status
-      );
+      throw new ResponseFailureError();
     })
     .catch(() => {
       updatePeriodicActionButtonsDisabledProperty({
@@ -408,10 +385,7 @@ function stopSendingPeriodicMessage() {
         return displaySuccessImg(buttonRowIds.PERIODIC_ACTIONS);
       }
 
-      throw new ResponseFailureError(
-        "An error occurred while processing stop request, code: " +
-          response.status
-      );
+      throw new ResponseFailureError();
     })
     .catch(() => {
       updatePeriodicActionButtonsDisabledProperty({

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -21,6 +21,10 @@ const suffixes = {
   ERROR_SPAN: "ErrorSpan"
 };
 
+function responseIsSuccess(response) {
+  return response.ok === true;
+}
+
 window.onload = function() {
   const getUrl = "/settings/current";
 
@@ -281,10 +285,6 @@ function checkIfPeriodicMessageIsValid() {
   const settings = getPeriodicMessageSettings();
 
   return isJson(settings.periodicMessage);
-}
-
-function responseIsSuccess(response) {
-  return response.ok === true;
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -30,7 +30,9 @@ window.onload = function() {
         return response.json();
       }
 
-      throw new ResponseFailureError();
+      throw new ResponseFailureError(
+        "Error during querying the current settings, code: " + response.status
+      );
     })
     .then(parsedResponseData => {
       setInputValues(parsedResponseData.currentSettings);
@@ -238,7 +240,9 @@ function disconnectAllClients() {
           return displaySuccessImg(buttonRowIds.DISCONNECT);
         }
 
-        throw new ResponseFailureError();
+        throw new ResponseFailureError(
+          "Error during disconnecting all clients, code: " + response.status
+        );
       })
       .catch(() => {
         displayErrorElements(buttonRowIds.DISCONNECT, "Server error");
@@ -303,7 +307,9 @@ function submitOnEventMessage() {
           return displaySuccessImg(buttonRowIds.ON_EVENT);
         }
 
-        throw new ResponseFailureError();
+        throw new ResponseFailureError(
+          "Error during saving `onEvent` message, code: " + response.status
+        );
       })
       .catch(() => {
         displayErrorElements(buttonRowIds.ON_EVENT, "Server error");
@@ -340,7 +346,9 @@ function submitPeriodicSettings() {
             });
           }
         } else {
-          throw new ResponseFailureError();
+          throw new ResponseFailureError(
+            "Error during saving `periodic` message, code: " + response.status
+          );
         }
       })
       .catch(() => {
@@ -369,7 +377,9 @@ function startSendingPeriodicMessage() {
         return displaySuccessImg(buttonRowIds.PERIODIC_ACTIONS);
       }
 
-      throw new ResponseFailureError();
+      throw new ResponseFailureError(
+        "Error during clicking on the start button, code: " + response.status
+      );
     })
     .catch(() => {
       updatePeriodicActionButtonsDisabledProperty({
@@ -397,7 +407,9 @@ function stopSendingPeriodicMessage() {
         return displaySuccessImg(buttonRowIds.PERIODIC_ACTIONS);
       }
 
-      throw new ResponseFailureError();
+      throw new ResponseFailureError(
+        "Error during clicking on the stop button, code: " + response.status
+      );
     })
     .catch(() => {
       updatePeriodicActionButtonsDisabledProperty({

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -378,7 +378,8 @@ function startSendingPeriodicMessage() {
       }
 
       throw new ResponseFailureError(
-        "Error during clicking on the start button, code: " + response.status
+        "An error occurred while processing the start request, code: " +
+          response.status
       );
     })
     .catch(() => {
@@ -408,7 +409,8 @@ function stopSendingPeriodicMessage() {
       }
 
       throw new ResponseFailureError(
-        "Error during clicking on the stop button, code: " + response.status
+        "An error occurred while processing the stop request, code: " +
+          response.status
       );
     })
     .catch(() => {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -378,7 +378,7 @@ function startSendingPeriodicMessage() {
       }
 
       throw new ResponseFailureError(
-        "An error occurred while processing the start request, code: " +
+        "An error occurred while processing start request, code: " +
           response.status
       );
     })
@@ -409,7 +409,7 @@ function stopSendingPeriodicMessage() {
       }
 
       throw new ResponseFailureError(
-        "An error occurred while processing the stop request, code: " +
+        "An error occurred while processing stop request, code: " +
           response.status
       );
     })


### PR DESCRIPTION
Third part of issue #19.

Prerequisite:
- [x] merge #20 and #21 into master.

**Demo**

Errors, new implementations can be tested [**here**](https://c-hive-ws-demo.herokuapp.com/).

**Changes**

- added `ResponseFailureError` in order to throw errors whenever `responseIsSuccess` returns false,
- `settingIsNotDefined` => `Setting` model functions should only be called whenever the base value is defined - this also spammed the console with errors previously,
- using response codes instead of raw JSON messages, thus the flow could be simplified.

**Questions**

1. **Is `settingIsNotDefined` unnecessary?**

IMO there're differences between the two cases below:

```js
if (!javaScriptUtils.isDefined(setting)) { ... }

// OR

if (settingIsNotDefined()) { ... }
```

The latter example might be more meaningful, however, I feel like it's just an extra "wrapper".

2. **How about using error messages in a different way?**

Similarly to the examples above:

```js
function startSendingPeriodicMessage() {
   // ...
   throw new ResponseFailureError("An error occurred while processing start request, code: " + response.status);
}

// OR

function startSendingPeriodicMessage() {
   // ...
   throw new ResponseFailureError("`startSendingPeriodicMessage` => " + response.status);
}
```

From my perspective, the second one is both shorter and slightly more expressive. On the other hand, the first one is much more readable.

@thisismydesign Could you help me out with these questions?
